### PR TITLE
Update: Return selected item on wheel start

### DIFF
--- a/src/components/Roulette.vue
+++ b/src/components/Roulette.vue
@@ -268,7 +268,7 @@ export default defineComponent ({
         this.itemAngle / 2 +
         this.degreesVariation
       }deg)`;
-      this.$emit("wheel-start");
+      this.$emit("wheel-start", this.itemSelected);
     },
   },
 });


### PR DESCRIPTION
You can return the selected item when the wheel starts, with this data we could prevent some items are selected multiple times or any other strategy using `wheel.value.reset()` before the wheel start and running again `wheel.value.launchWheel ()` for necessary times after the wheel unselect the option that we wan't